### PR TITLE
Clean duplicate package-lock.json file from wrong directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "interior-design-platform",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## Summary
- Removed duplicated package-lock.json file from incorrect directory
- Kept the correct package-lock.json in the proper frontend path
Related to #19, #20, #21, #22, #26, #27