### PR TITLE
Frontend: Request Details With Accept and Reject Actions

### DIFF
--- a/frontend/src/pages/designer/RequestDetails.jsx
+++ b/frontend/src/pages/designer/RequestDetails.jsx
@@ -15,7 +15,13 @@ const RequestDetailsPage = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
-  const requestId = window.location.pathname.split("/").filter(Boolean).pop() || 15;
+  const [actionLoading, setActionLoading] = useState("");
+  const [actionMessage, setActionMessage] = useState("");
+  const [actionError, setActionError] = useState("");
+
+  const requestId =
+    window.location.pathname.split("/").filter(Boolean).pop() || 15;
+
   const API_URL = `http://localhost:5000/design-requests/${requestId}`;
 
   useEffect(() => {
@@ -43,6 +49,83 @@ const RequestDetailsPage = () => {
 
     fetchRequestDetails();
   }, [API_URL]);
+
+  const handleRequestAction = async (action) => {
+    const isAccept = action === "accept";
+    const confirmed = window.confirm(
+      isAccept
+        ? "Are you sure you want to accept this request?"
+        : "Are you sure you want to reject this request?"
+    );
+
+    if (!confirmed) return;
+
+    try {
+      setActionLoading(action);
+      setActionMessage("");
+      setActionError("");
+
+      const response = await fetch(`${API_URL}/${action}`, {
+        method: isAccept ? "POST" : "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        setActionError(data.error || "Unable to update request status");
+        return;
+      }
+
+      setActionMessage(
+        data.message ||
+          (isAccept
+            ? "Request accepted successfully"
+            : "Request rejected successfully")
+      );
+
+      setRequest((prev) => ({
+        ...prev,
+        status: isAccept ? "accepted" : "rejected",
+      }));
+    } catch (error) {
+      setActionError("Unable to connect to backend. Please try again.");
+      console.error("Action error:", error);
+    } finally {
+      setActionLoading("");
+    }
+  };
+
+  const formatBudget = (budget) => {
+    if (budget === undefined || budget === null || budget === "") {
+      return "N/A";
+    }
+
+    return `${Number(budget).toLocaleString()} SAR`;
+  };
+
+  const getStatusStyle = (status) => {
+    if (status === "accepted") {
+      return {
+        backgroundColor: "#E8F5E9",
+        color: "#2E7D32",
+      };
+    }
+
+    if (status === "rejected") {
+      return {
+        backgroundColor: "#FFEBEE",
+        color: "#C62828",
+      };
+    }
+
+    return {
+      backgroundColor: "#FFF3E0",
+      color: "#E65100",
+    };
+  };
 
   const pageStyle = {
     minHeight: "100vh",
@@ -84,20 +167,39 @@ const RequestDetailsPage = () => {
     display: "inline-block",
     padding: "8px 14px",
     borderRadius: "10px",
-    backgroundColor: "#FFF3E0",
-    color: "#E65100",
     fontSize: "12px",
     fontWeight: "700",
     textTransform: "uppercase",
+    ...getStatusStyle(request.status),
   };
 
-  const formatBudget = (budget) => {
-    if (budget === undefined || budget === null || budget === "") {
-      return "N/A";
-    }
-
-    return `${Number(budget).toLocaleString()} SAR`;
+  const primaryButtonStyle = {
+    width: "100%",
+    border: "none",
+    backgroundColor: "#2C221A",
+    color: "#FFFDF9",
+    borderRadius: "10px",
+    padding: "14px 18px",
+    cursor: "pointer",
+    fontWeight: "700",
+    textTransform: "uppercase",
+    letterSpacing: "0.5px",
   };
+
+  const secondaryButtonStyle = {
+    width: "100%",
+    border: "2px solid #2C221A",
+    backgroundColor: "transparent",
+    color: "#2C221A",
+    borderRadius: "10px",
+    padding: "12px 18px",
+    cursor: "pointer",
+    fontWeight: "700",
+    textTransform: "uppercase",
+    letterSpacing: "0.5px",
+  };
+
+  const isPending = request.status === "pending";
 
   return (
     <div style={pageStyle}>
@@ -244,6 +346,79 @@ const RequestDetailsPage = () => {
             </p>
           )}
         </div>
+
+        {isPending ? (
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+              gap: "16px",
+              marginBottom: "24px",
+            }}
+          >
+            <button
+              type="button"
+              onClick={() => handleRequestAction("accept")}
+              disabled={actionLoading !== ""}
+              style={{
+                ...primaryButtonStyle,
+                opacity: actionLoading ? 0.7 : 1,
+                cursor: actionLoading ? "not-allowed" : "pointer",
+              }}
+            >
+              {actionLoading === "accept" ? "Processing..." : "Accept Request"}
+            </button>
+
+            <button
+              type="button"
+              onClick={() => handleRequestAction("reject")}
+              disabled={actionLoading !== ""}
+              style={{
+                ...secondaryButtonStyle,
+                opacity: actionLoading ? 0.7 : 1,
+                cursor: actionLoading ? "not-allowed" : "pointer",
+              }}
+            >
+              {actionLoading === "reject" ? "Processing..." : "Reject Request"}
+            </button>
+          </div>
+        ) : (
+          <div style={cardStyle}>
+            <p style={{ color: "#8C7B68", margin: 0 }}>
+              This request has already been {request.status}.
+            </p>
+          </div>
+        )}
+
+        {actionMessage && (
+          <div
+            style={{
+              border: "1px solid #C8E6C9",
+              backgroundColor: "#E8F5E9",
+              color: "#2E7D32",
+              borderRadius: "10px",
+              padding: "14px 16px",
+              marginBottom: "24px",
+            }}
+          >
+            {actionMessage}
+          </div>
+        )}
+
+        {actionError && (
+          <div
+            style={{
+              border: "1px solid #FFCDD2",
+              backgroundColor: "#FFEBEE",
+              color: "#C62828",
+              borderRadius: "10px",
+              padding: "14px 16px",
+              marginBottom: "24px",
+            }}
+          >
+            {actionError}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/designer/RequestDetails.jsx
+++ b/frontend/src/pages/designer/RequestDetails.jsx
@@ -1,1 +1,252 @@
+import React, { useEffect, useState } from "react";
 
+const RequestDetailsPage = () => {
+  const [request, setRequest] = useState({
+    id: 15,
+    client_name: "Ahmed",
+    space_type: "Villa",
+    style: "Modern",
+    budget: 40000,
+    description: "Luxury modern villa",
+    status: "pending",
+    attachments: [],
+  });
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const requestId = window.location.pathname.split("/").filter(Boolean).pop() || 15;
+  const API_URL = `http://localhost:5000/design-requests/${requestId}`;
+
+  useEffect(() => {
+    const fetchRequestDetails = async () => {
+      try {
+        setLoading(true);
+        setError("");
+
+        const response = await fetch(API_URL);
+        const data = await response.json();
+
+        if (!response.ok) {
+          setError(data.error || "Design request not found");
+          return;
+        }
+
+        setRequest(data);
+      } catch (error) {
+        setError("Unable to connect to backend. Showing sample request.");
+        console.error("Network error:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchRequestDetails();
+  }, [API_URL]);
+
+  const pageStyle = {
+    minHeight: "100vh",
+    backgroundColor: "#F6F1EA",
+    padding: "48px 24px",
+    fontFamily: "Arial, sans-serif",
+  };
+
+  const containerStyle = {
+    maxWidth: "900px",
+    margin: "0 auto",
+  };
+
+  const cardStyle = {
+    backgroundColor: "#FFFDF9",
+    border: "1px solid #E2D8CE",
+    borderRadius: "18px",
+    padding: "28px",
+    marginBottom: "24px",
+  };
+
+  const labelStyle = {
+    fontSize: "12px",
+    textTransform: "uppercase",
+    letterSpacing: "1px",
+    color: "#8C7B68",
+    marginBottom: "8px",
+    fontWeight: "600",
+  };
+
+  const valueStyle = {
+    color: "#2C221A",
+    fontSize: "16px",
+    fontWeight: "600",
+    margin: 0,
+  };
+
+  const statusStyle = {
+    display: "inline-block",
+    padding: "8px 14px",
+    borderRadius: "10px",
+    backgroundColor: "#FFF3E0",
+    color: "#E65100",
+    fontSize: "12px",
+    fontWeight: "700",
+    textTransform: "uppercase",
+  };
+
+  const formatBudget = (budget) => {
+    if (budget === undefined || budget === null || budget === "") {
+      return "N/A";
+    }
+
+    return `${Number(budget).toLocaleString()} SAR`;
+  };
+
+  return (
+    <div style={pageStyle}>
+      <div style={containerStyle}>
+        <button
+          type="button"
+          onClick={() => window.history.back()}
+          style={{
+            marginBottom: "24px",
+            border: "1px solid #E2D8CE",
+            backgroundColor: "transparent",
+            color: "#2C221A",
+            borderRadius: "8px",
+            padding: "10px 16px",
+            cursor: "pointer",
+            fontWeight: "600",
+          }}
+        >
+          ← Back to Dashboard
+        </button>
+
+        <div style={cardStyle}>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              gap: "20px",
+              alignItems: "flex-start",
+            }}
+          >
+            <div>
+              <p style={labelStyle}>Request Details</p>
+              <h1
+                style={{
+                  color: "#2C221A",
+                  fontSize: "42px",
+                  fontWeight: "400",
+                  margin: "0 0 10px 0",
+                }}
+              >
+                Request #{request.id}
+              </h1>
+              <p style={{ color: "#8C7B68", margin: 0 }}>
+                Detailed information for a specific design request.
+              </p>
+            </div>
+
+            <span style={statusStyle}>{request.status}</span>
+          </div>
+        </div>
+
+        {loading && (
+          <div style={cardStyle}>
+            <p style={{ color: "#8C7B68", margin: 0 }}>
+              Loading request details...
+            </p>
+          </div>
+        )}
+
+        {error && (
+          <div
+            style={{
+              border: "1px solid #F5D48B",
+              backgroundColor: "#FFF8E1",
+              color: "#8A5A00",
+              borderRadius: "10px",
+              padding: "14px 16px",
+              marginBottom: "24px",
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        <div style={cardStyle}>
+          <p style={labelStyle}>Client Name</p>
+          <p style={valueStyle}>{request.client_name}</p>
+        </div>
+
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+            gap: "20px",
+            marginBottom: "24px",
+          }}
+        >
+          <div style={cardStyle}>
+            <p style={labelStyle}>Space Type</p>
+            <p style={valueStyle}>{request.space_type}</p>
+          </div>
+
+          <div style={cardStyle}>
+            <p style={labelStyle}>Design Style</p>
+            <p style={valueStyle}>{request.style}</p>
+          </div>
+
+          <div style={cardStyle}>
+            <p style={labelStyle}>Budget</p>
+            <p style={valueStyle}>{formatBudget(request.budget)}</p>
+          </div>
+        </div>
+
+        <div style={cardStyle}>
+          <p style={labelStyle}>Project Description</p>
+          <p
+            style={{
+              color: "#3D3128",
+              lineHeight: "1.7",
+              margin: 0,
+            }}
+          >
+            {request.description}
+          </p>
+        </div>
+
+        <div style={cardStyle}>
+          <p style={labelStyle}>Attachments</p>
+
+          {request.attachments && request.attachments.length > 0 ? (
+            <div>
+              {request.attachments.map((attachment, index) => (
+                <a
+                  key={attachment.id || index}
+                  href={attachment.url || "#"}
+                  style={{
+                    display: "block",
+                    color: "#2C221A",
+                    textDecoration: "none",
+                    border: "1px solid #E2D8CE",
+                    borderRadius: "10px",
+                    padding: "12px 14px",
+                    marginBottom: "10px",
+                    backgroundColor: "#F6F1EA",
+                  }}
+                >
+                  {attachment.name || `Attachment ${index + 1}`}
+                </a>
+              ))}
+            </div>
+          ) : (
+            <p style={{ color: "#8C7B68", margin: 0 }}>
+              No attachments available.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RequestDetailsPage;


### PR DESCRIPTION
Implemented Request Details Page for issue #104.

What was added:
- Added request details page UI
- Added GET request to /design-requests/:id
- Displayed required response fields:
  - id
  - client_name
  - space_type
  - style
  - budget
  - description
  - status
  - attachments
- Added loading state
- Added error handling for unavailable or missing request
- Added fallback sample request for local preview when backend is not running
- Added attachments section

Notes:
- UI tested locally.
- Backend was not running locally, so fallback sample data was used for preview.
- App.jsx was only used temporarily for preview and restored before commit.
<img width="1920" height="1200" alt="Screen Shot 1447-11-26 at 11 02 12 PM" src="https://github.com/user-attachments/assets/4b1d2091-cd0f-4821-b79c-478e2eef76ac" />
